### PR TITLE
Docker: mat inn secrets/repo

### DIFF
--- a/.github/workflows/harbor.yaml
+++ b/.github/workflows/harbor.yaml
@@ -18,21 +18,17 @@ jobs:
     name: Push Docker image to Harbor
     runs-on: ubuntu-latest
     env:
-        IMAGE_NAME: ${{ github.repository }}
+      IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: "Dockerfile"
-      - name: R setup
-        uses: r-lib/actions/setup-r@v2
-      - name: Build package (tarball)
-        run: R CMD build .
       - name: Prepare tags
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_NAME }}
           flavor: |
@@ -42,17 +38,20 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Login to Harbor
         if: github.event_name == 'release'
         run: |
           echo ${{ secrets.HARBOR_PASSWORD }} | docker login --username ${{ secrets.HARBOR_USERNAME }} --password-stdin ${{ secrets.HARBOR_REGISTRY }}
       - name: Build image and push to Harbor
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           tags: ${{ secrets.HARBOR_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
           push: ${{ github.event_name == 'release' }}
+          pull: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            "github_pat=${{ secrets.GITHUB_TOKEN }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
 FROM rapporteket/base-r:main
 
-LABEL maintainer="Kevin Thon <kevin.otto.thon@helse-nord.no>"
-LABEL no.rapporteket.cd.enable="true"
-
 WORKDIR /app/R
 
-COPY *.tar.gz .
-
-RUN R -e "remotes::install_local(list.files(pattern = \"*.tar.gz\"))" \
-  && rm ./*.tar.gz \
+RUN --mount=type=secret,id=github_pat,env=GITHUB_PAT \
+    --mount=type=bind,source=.,target=/app/R/pkg \
+    R -e "remotes::install_local(path = './pkg')" \
   && R -e "remotes::install_github(\"Rapporteket/rapbase\", ref = \"main\")"
 
 EXPOSE 3838


### PR DESCRIPTION
- Matet inn secrets, slik at de ikke være synlig i bygg etterpå.
- Matet inn repo og bygde pakken inne i Dockerfile. Det betyr at det ikke lenger er nødvendig å bygge en tar.gz-fil utenfor før man bygger image. Da slipper man å sette opp R-miljø i action.